### PR TITLE
Fix karma dependency and replace depreciated gulp-webpack

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 var gulp = require('gulp');
 var tslint = require('gulp-tslint');
-var webpack = require('gulp-webpack');
+var webpack = require('webpack-stream');
 
 gulp.task('default', ['watch-tslint']);
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp": "~3.9.0",
     "gulp-tslint": "~3.3.0",
     "gulp-watch": "~4.3.5",
-    "gulp-webpack": "~1.5.0",
+    "jasmine-core": "^2.3.4",
     "karma": "~0.13.10",
     "karma-chrome-launcher": "~0.2.0",
     "karma-cli": "~0.1.1",
@@ -42,6 +42,7 @@
     "typescript": "~1.6.2",
     "webpack": "~1.12.2",
     "webpack-config": "~1.0.2",
-    "webpack-dev-server": "~1.12.0"
+    "webpack-dev-server": "~1.12.0",
+    "webpack-stream": "^2.1.1"
   }
 }


### PR DESCRIPTION
Added jasmine-core to package.json. npm install would fail on karma even if jasmine-core was installed globally.

Also gulp-webpack looks to be depreciated, now points to webpack-stream, so I added that as well.
