### PR TITLE
Don't export action names

### DIFF
--- a/App/ActionCreators/ContentActionCreators.ts
+++ b/App/ActionCreators/ContentActionCreators.ts
@@ -6,5 +6,5 @@ export function loadContent(): ReduxActions.Action<ContentLoadActionPayload> {
         "LESS in combination of CSS modules is used for styling components. For running, building and bundling there is powerful Webpack. " +
         "Check the console logs as you click around the page and install redux devtools chrome extenstion for better development experience.";
 
-    return contentLoadAction({title, summary});
+    return contentLoadAction(title, summary);
 }

--- a/App/ActionCreators/SubredditsActionCreators.ts
+++ b/App/ActionCreators/SubredditsActionCreators.ts
@@ -4,10 +4,10 @@ import * as SubredditsProvider from "./../DataLayer/SubredditsProvider";
 
 export function fetchPosts(subreddit: string): (dispatcher: Dispatch<{}>) => Promise<{}> {
     return (dispatch: Dispatch<{}>) => {
-        dispatch(getSubredditPostsStartAction({subreddit}));
+        dispatch(getSubredditPostsStartAction(subreddit));
 
         return SubredditsProvider.fetchPosts(subreddit)
-            .then((result: Post[]) => dispatch(getSubredditPostsSuccessAction({subreddit, posts: result})))
+            .then((result: Post[]) => dispatch(getSubredditPostsSuccessAction(subreddit, result)))
             .catch(() => dispatch(getSubredditPostsErrorAction({subreddit, error: "FETCHING_ERROR"})));
     };
 }

--- a/App/Actions/ContentLoadAction.ts
+++ b/App/Actions/ContentLoadAction.ts
@@ -1,10 +1,9 @@
 import { createAction } from "redux-actions";
 
-export const CONTENT_LOAD_ACTION = "ContentLoadAction";
-
 export interface ContentLoadActionPayload  {
     title: string;
     summary: string;
 }
 
-export const contentLoadAction = createAction<ContentLoadActionPayload, ContentLoadActionPayload>(CONTENT_LOAD_ACTION, undefined);
+export const contentLoadAction =
+    createAction<ContentLoadActionPayload, string, string>("ContentLoadAction", (title, summary) => ({title, summary}));

--- a/App/Actions/GetSubredditPostsActions.ts
+++ b/App/Actions/GetSubredditPostsActions.ts
@@ -1,9 +1,5 @@
 import { createAction } from "redux-actions";
 
-export const GET_SUBREDDIT_POSTS_START_ACTION = "GetSubredditPostsStartAction";
-export const GET_SUBREDDIT_POSTS_SUCCESS_ACTION = "GetSubredditPostsSuccessAction";
-export const GET_SUBREDDIT_POSTS_ERROR_ACTION = "GetSubredditPostsErrorAction";
-
 export interface GetSubredditPostsStartActionPayload {
     subreddit: string;
 }
@@ -19,8 +15,10 @@ export interface GetSubredditPostsErrorActionPayload {
 }
 
 export const getSubredditPostsStartAction =
-    createAction<GetSubredditPostsStartActionPayload, GetSubredditPostsStartActionPayload>(GET_SUBREDDIT_POSTS_START_ACTION, undefined);
+    createAction<GetSubredditPostsStartActionPayload, string>("GetSubredditPostsStartAction", (subreddit) => ({subreddit}));
+// an example utilizing payloadCreator
 export const getSubredditPostsSuccessAction =
-    createAction<GetSubredditPostsSuccessActionPayload, GetSubredditPostsSuccessActionPayload>(GET_SUBREDDIT_POSTS_SUCCESS_ACTION, undefined);
+    createAction<GetSubredditPostsSuccessActionPayload, string, Post[]>("GetSubredditPostsSuccessAction", (subreddit, posts) => ({subreddit, posts}));
+// createAction without payloadCreator
 export const getSubredditPostsErrorAction =
-    createAction<GetSubredditPostsErrorActionPayload, GetSubredditPostsErrorActionPayload>(GET_SUBREDDIT_POSTS_ERROR_ACTION, undefined);
+    createAction<GetSubredditPostsErrorActionPayload, GetSubredditPostsErrorActionPayload>("GetSubredditPostsErrorAction", undefined);

--- a/App/Actions/SayHelloAction.ts
+++ b/App/Actions/SayHelloAction.ts
@@ -1,5 +1,3 @@
 import { createAction } from "redux-actions";
 
-export const SAY_HELLO_ACTION = "SayHelloAction";
-
-export const sayHelloAction = createAction<void>(SAY_HELLO_ACTION, undefined);
+export const sayHelloAction = createAction<void>("SayHelloAction", undefined);

--- a/App/Reducers/ContentReducer.ts
+++ b/App/Reducers/ContentReducer.ts
@@ -1,5 +1,5 @@
 import { handleActions } from "redux-actions";
-import { CONTENT_LOAD_ACTION, ContentLoadActionPayload } from "./../Actions/ContentLoadAction";
+import { ContentLoadActionPayload, contentLoadAction } from "./../Actions/ContentLoadAction";
 import { ContentState } from "./../Store/State/ContentState";
 
 const initialState: ContentState = {
@@ -8,7 +8,7 @@ const initialState: ContentState = {
 };
 
 export default handleActions<ContentState, ContentLoadActionPayload>({
-    [CONTENT_LOAD_ACTION]: (state, action) => {
+    [contentLoadAction.toString()]: (state, action) => {
         return {
             title: action.payload.title ? action.payload.title.toUpperCase() : "",
             summary: action.payload.summary,

--- a/App/Reducers/HelloCountReducer.ts
+++ b/App/Reducers/HelloCountReducer.ts
@@ -1,5 +1,5 @@
 import { handleActions } from "redux-actions";
-import { sayHelloAction, SAY_HELLO_ACTION } from "./../Actions/SayHelloAction";
+import { sayHelloAction } from "./../Actions/SayHelloAction";
 import { HelloCountState } from "./../Store/State/HelloCountState";
 
 const initialState: HelloCountState = {
@@ -7,7 +7,7 @@ const initialState: HelloCountState = {
 };
 
 export default handleActions<HelloCountState, void>({
-    [SAY_HELLO_ACTION]: (state, action) => {
+    [sayHelloAction.toString()]: (state, action) => {
         return {
             count: state.count + 1,
         };

--- a/App/Reducers/SubredditsReducer.ts
+++ b/App/Reducers/SubredditsReducer.ts
@@ -1,7 +1,7 @@
 import { handleActions } from "redux-actions";
-import { GET_SUBREDDIT_POSTS_START_ACTION, GET_SUBREDDIT_POSTS_SUCCESS_ACTION, GET_SUBREDDIT_POSTS_ERROR_ACTION,
-    GetSubredditPostsStartActionPayload, GetSubredditPostsSuccessActionPayload, GetSubredditPostsErrorActionPayload }
-    from "./../Actions/GetSubredditPostsActions";
+import { getSubredditPostsStartAction, getSubredditPostsSuccessAction, getSubredditPostsErrorAction,
+    GetSubredditPostsStartActionPayload, GetSubredditPostsSuccessActionPayload,
+    GetSubredditPostsErrorActionPayload } from "./../Actions/GetSubredditPostsActions";
 import { SubredditsState } from "./../Store/State/SubredditsState";
 
 const initialState: SubredditsState = {
@@ -10,7 +10,7 @@ const initialState: SubredditsState = {
 };
 
 export default handleActions<SubredditsState>({
-    [GET_SUBREDDIT_POSTS_START_ACTION]: (state, action: ReduxActions.Action<GetSubredditPostsStartActionPayload>) => {
+    [getSubredditPostsStartAction.toString()]: (state, action: ReduxActions.Action<GetSubredditPostsStartActionPayload>) => {
         return {
             selectedSubreddit: action.payload.subreddit,
             items: {
@@ -25,7 +25,7 @@ export default handleActions<SubredditsState>({
         };
     },
 
-    [GET_SUBREDDIT_POSTS_SUCCESS_ACTION]: (state, action: ReduxActions.Action<GetSubredditPostsSuccessActionPayload>) => {
+    [getSubredditPostsSuccessAction.toString()]: (state, action: ReduxActions.Action<GetSubredditPostsSuccessActionPayload>) => {
         const updatedItem = {
             ...state.items[action.payload.subreddit],
             isLoading: false,
@@ -41,7 +41,7 @@ export default handleActions<SubredditsState>({
         };
     },
 
-    [GET_SUBREDDIT_POSTS_ERROR_ACTION]: (state, action: GetSubredditPostsErrorActionPayload) => {
+    [getSubredditPostsErrorAction.toString()]: (state, action: GetSubredditPostsErrorActionPayload) => {
         const errorItem = {
             ...state.items[action.subreddit],
             isLoading: false,


### PR DESCRIPTION
Action names are not necessary and increase the boilerplate code which has to been written. 

The changes contain also some examples how to use payload creator in Redux-actions/createAction.